### PR TITLE
Add simple mode and tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Experimental-
-Random 
+
+This repository contains browser-based music generation experiments.
+
+## Files
+- `public/index.html`: Retro AI Music Lab with simple and advanced modes.
+- `public/neural-beat-studio.html`: Starter layout for **Neural Beat Studio Pro**, a tabbed interface for studio, arrangement, mixer, and effects views.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retro AI Music Generator</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div id="app">
+    <h1>Retro AI Music Lab</h1>
+
+    <div id="tabs">
+      <button id="tabSimple" class="active">Simple</button>
+      <button id="tabAdvanced">Advanced</button>
+    </div>
+
+    <section id="simpleMode">
+      <textarea id="prompt" placeholder="Describe the music..."></textarea>
+      <button id="promptGenerate">Generate</button>
+
+      <div id="controlsSimple" class="controls">
+        <button id="playSimple">Play</button>
+        <button id="pauseSimple">Pause</button>
+        <button id="resumeSimple">Resume</button>
+        <button id="stopSimple">Stop</button>
+      </div>
+
+      <div id="vote">
+        <button id="like">👍</button>
+        <button id="dislike">👎</button>
+      </div>
+    </section>
+
+    <section id="advancedMode" class="hidden">
+      <div id="upload-section">
+        <input type="file" id="midiUpload" accept=".mid,.midi" />
+        <button id="generate">Generate</button>
+      </div>
+
+      <pre id="status">Idle</pre>
+
+      <section id="sequencer"></section>
+
+      <div id="controlsAdvanced" class="controls">
+        <button id="play">Play</button>
+        <button id="pause">Pause</button>
+        <button id="resume">Resume</button>
+        <button id="stop">Stop</button>
+      </div>
+
+      <section id="mixer"></section>
+    </section>
+
+  </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.39/Tone.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tonejs/midi@2.0.27/build/Midi.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@magenta/music@1.27.0/dist/magenta.min.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/neural-beat-studio.html
+++ b/public/neural-beat-studio.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Neural Beat Studio Pro</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <style>
+    /* Modern and Mobile-Optimized UI for Neural Beat Studio Pro */
+    :root {
+      --primary-color: #6e6dff;
+      --primary-dark: #5D5CDE;
+      --primary-light: #9f9fff;
+      --secondary-color: #ff6e4a;
+      --success-color: #4CAF50;
+      --danger-color: #f25b45;
+      --warning-color: #ffc107;
+      --dark-background: #121214;
+      --dark-surface: #1e1e22;
+      --dark-panel: #252529;
+      --dark-border: #38383d;
+      --dark-text: #e0e0e5;
+      --dark-text-secondary: #8e8ea0;
+      --light-background: #FFFFFF;
+      --light-surface: #F5F5F5;
+      --light-panel: #EFEFEF;
+      --light-border: #D1D1D1;
+      --light-text: #333333;
+      --light-text-secondary: #666666;
+    }
+
+    /* Dark Mode Detection */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --background: var(--dark-background);
+        --surface: var(--dark-surface);
+        --panel: var(--dark-panel);
+        --border: var(--dark-border);
+        --text: var(--dark-text);
+        --text-secondary: var(--dark-text-secondary);
+      }
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --background: var(--light-background);
+        --surface: var(--light-surface);
+        --panel: var(--light-panel);
+        --border: var(--light-border);
+        --text: var(--light-text);
+        --text-secondary: var(--light-text-secondary);
+      }
+    }
+
+    /* Base Styles */
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-size: 16px;
+      line-height: 1.5;
+      background-color: var(--background);
+      color: var(--text);
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    /* Studio Background Texture */
+    .studio-texture {
+      background-color: var(--dark-background);
+      background-image:
+        linear-gradient(145deg, rgba(25, 25, 30, 0.5), rgba(18, 18, 20, 0.7)),
+        repeating-linear-gradient(to right, rgba(40, 40, 45, 0.03) 1px, transparent 1px, transparent 20px),
+        repeating-linear-gradient(to bottom, rgba(40, 40, 45, 0.03) 1px, transparent 1px, transparent 20px),
+        radial-gradient(circle at 25% 25%, rgba(110, 109, 255, 0.05) 0%, transparent 50%),
+        radial-gradient(circle at 75% 75%, rgba(255, 87, 34, 0.03) 0%, transparent 50%);
+    }
+
+    /* Header Styling */
+    .studio-header {
+      background: linear-gradient(145deg, rgba(58, 58, 181, 0.9), rgba(93, 92, 222, 0.8));
+      border-radius: 0.75rem;
+      padding: 1rem;
+      text-align: center;
+      box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+      border: 1px solid rgba(110, 109, 255, 0.3);
+      margin-bottom: 1.5rem;
+    }
+
+    .pro-badge {
+      background-color: rgba(255, 215, 0, 0.2);
+      border: 1px solid rgba(255, 215, 0, 0.5);
+      border-radius: 0.25rem;
+      padding: 0.1rem 0.3rem;
+      margin-left: 0.5rem;
+      font-size: 0.75rem;
+      color: #FFD700;
+      box-shadow: 0 0 8px rgba(255, 215, 0, 0.3);
+      vertical-align: middle;
+    }
+
+    /* Tab Navigation */
+    .tab-navigation {
+      display: flex;
+      flex-wrap: wrap;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 1rem;
+      gap: 0.125rem;
+    }
+
+    .tab-button {
+      padding: 0.5rem 1rem;
+      background: rgba(30, 30, 34, 0.8);
+      color: var(--text-secondary);
+      border: none;
+      border-top-left-radius: 0.375rem;
+      border-top-right-radius: 0.375rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      border: 1px solid var(--border);
+      border-bottom: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      margin-right: 1px;
+    }
+
+    .tab-button:hover {
+      background: rgba(37, 37, 41, 0.9);
+      color: var(--text);
+    }
+
+    .tab-button.active {
+      background: linear-gradient(to bottom, var(--primary-color), var(--primary-dark));
+      color: white;
+      font-weight: bold;
+      box-shadow: 0 0 15px rgba(110, 109, 255, 0.3);
+    }
+
+    .tab-content {
+      display: none;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+  </style>
+</head>
+
+<body class="studio-texture">
+  <div class="container mx-auto px-2 py-3 max-w-4xl">
+    <div class="studio-header mb-4">
+      <h1 class="text-2xl sm:text-3xl font-bold text-white flex justify-center items-center">
+        <svg class="h-6 w-6 mr-2" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 18.5V19.5M8.2 18.5V19.5M15.8 18.5V19.5M7.5 14.5H16.5M7.5 11H16.5M7.5 7.5H16.5M5.5 21H18.5C19.6046 21 20.5 20.1046 20.5 19V5C20.5 3.89543 19.6046 3 18.5 3H5.5C4.39543 3 3.5 3.89543 3.5 5V19C3.5 20.1046 4.39543 21 5.5 21Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+        NEURAL BEAT <span class="pro-badge">PRO</span>
+      </h1>
+      <p class="text-sm text-indigo-200">AI-Powered Music Production</p>
+    </div>
+
+    <!-- Minimal demo: tab structure only -->
+    <div class="tab-navigation mb-3">
+      <button class="tab-button active" data-tab="studio">Studio</button>
+      <button class="tab-button" data-tab="arrangement">Arrange</button>
+      <button class="tab-button" data-tab="mixer">Mixer</button>
+      <button class="tab-button" data-tab="effects">FX</button>
+    </div>
+
+    <div id="studio" class="tab-content active">
+      <p class="text-gray-300">Studio tab placeholder</p>
+    </div>
+    <div id="arrangement" class="tab-content">
+      <p class="text-gray-300">Arrangement tab placeholder</p>
+    </div>
+    <div id="mixer" class="tab-content">
+      <p class="text-gray-300">Mixer tab placeholder</p>
+    </div>
+    <div id="effects" class="tab-content">
+      <p class="text-gray-300">Effects tab placeholder</p>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.tab-button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById(btn.dataset.tab).classList.add('active');
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/public/retro-studio.html
+++ b/public/retro-studio.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Retro AI Music Lab</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.39/Tone.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tonejs/midi@2.0.27/build/Midi.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@magenta/music@1.27.0/dist/magenta.min.js"></script>
+  <style>
+    body { background:#111; color:#0f0; font-family:'Press Start 2P',cursive; display:flex; justify-content:center; align-items:center; height:100vh; margin:0; }
+    #app { text-align:center; background:#222; padding:20px; border:4px solid #0f0; }
+    #tabs { margin-bottom:10px; }
+    #tabs button.active { background:#8f8; }
+    .hidden { display:none; }
+    textarea { width:100%; height:60px; margin-top:10px; font-family:inherit; }
+    button { font-family:inherit; margin:5px; padding:10px 20px; background:#0f0; color:#000; border:none; cursor:pointer; }
+    button:hover { background:#8f8; }
+    #vote { margin-top:10px; }
+    #vote button { padding:5px 10px; }
+    pre { white-space:pre-wrap; text-align:left; background:#000; padding:10px; margin-top:10px; color:#0f0; max-height:150px; overflow-y:auto; }
+    #sequencer table { border-collapse:collapse; margin:10px auto; }
+    #sequencer th,#sequencer td { border:1px solid #0f0; padding:2px; }
+    #sequencer td label { display:block; width:20px; height:20px; background:#000; cursor:pointer; }
+    #sequencer input[type="checkbox"] { display:none; }
+    #sequencer input[type="checkbox"]:checked + label { background:#0f0; }
+    #mixer { display:flex; justify-content:center; margin-top:20px; }
+    .channel { border:1px solid #0f0; padding:5px; margin:0 2px; text-align:center; }
+    .fader { writing-mode:bt-lr; -webkit-appearance:slider-vertical; width:30px; height:100px; }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <h1>Retro AI Music Lab</h1>
+    <div id="tabs">
+      <button id="tabSimple" class="active">Simple</button>
+      <button id="tabAdvanced">Advanced</button>
+    </div>
+
+    <section id="simpleMode">
+      <textarea id="prompt" placeholder="Describe the music..."></textarea>
+      <button id="promptGenerate">Generate</button>
+      <div id="controlsSimple" class="controls">
+        <button id="playSimple">Play</button>
+        <button id="pauseSimple">Pause</button>
+        <button id="resumeSimple">Resume</button>
+        <button id="stopSimple">Stop</button>
+      </div>
+      <div id="vote">
+        <button id="like">👍</button>
+        <button id="dislike">👎</button>
+      </div>
+    </section>
+
+    <section id="advancedMode" class="hidden">
+      <div id="upload-section">
+        <input type="file" id="midiUpload" accept=".mid,.midi" />
+        <button id="generate">Generate</button>
+      </div>
+      <pre id="status">Idle</pre>
+      <section id="sequencer"></section>
+      <div id="controlsAdvanced" class="controls">
+        <button id="play">Play</button>
+        <button id="pause">Pause</button>
+        <button id="resume">Resume</button>
+        <button id="stop">Stop</button>
+      </div>
+      <section id="mixer"></section>
+    </section>
+  </div>
+
+  <script>
+  const tabSimple=document.getElementById('tabSimple');
+  const tabAdvanced=document.getElementById('tabAdvanced');
+  const simpleMode=document.getElementById('simpleMode');
+  const advancedMode=document.getElementById('advancedMode');
+  const promptEl=document.getElementById('prompt');
+  const promptGenerate=document.getElementById('promptGenerate');
+  const statusEl=document.getElementById('status');
+  const midiUpload=document.getElementById('midiUpload');
+  const playBtn=document.getElementById('play');
+  const stopBtn=document.getElementById('stop');
+  const pauseBtn=document.getElementById('pause');
+  const resumeBtn=document.getElementById('resume');
+  const likeBtn=document.getElementById('like');
+  const dislikeBtn=document.getElementById('dislike');
+  const sequencer=document.getElementById('sequencer');
+  const mixer=document.getElementById('mixer');
+
+  let generatedPart, synth, currentSeq;
+
+  function showSimple(){simpleMode.classList.remove('hidden');advancedMode.classList.add('hidden');tabSimple.classList.add('active');tabAdvanced.classList.remove('active');}
+  function showAdvanced(){advancedMode.classList.remove('hidden');simpleMode.classList.add('hidden');tabAdvanced.classList.add('active');tabSimple.classList.remove('active');if(!sequencer.hasChildNodes()) buildSequencer();if(!mixer.hasChildNodes()) buildMixer();}
+  tabSimple.onclick=showSimple;tabAdvanced.onclick=showAdvanced;showSimple();
+
+  const steps=16;const tracks=[{name:'Kick',create:()=>new Tone.MembraneSynth({pitchDecay:0.05})},{name:'Snare',create:()=>new Tone.NoiseSynth({envelope:{attack:0.001,decay:0.2,sustain:0}})},{name:'HiHat',create:()=>new Tone.NoiseSynth({envelope:{attack:0.001,decay:0.05,sustain:0}})},{name:'OpenHat',create:()=>new Tone.NoiseSynth({envelope:{attack:0.001,decay:0.3,sustain:0}})},{name:'Tom',create:()=>new Tone.MembraneSynth({octaves:2})},{name:'Cymbal',create:()=>new Tone.MetalSynth()},{name:'FMSynth',create:()=>new Tone.FMSynth()},{name:'Granular',create:()=>new Tone.GrainPlayer('https://tonejs.github.io/audio/berklee/gong_1.mp3')}];
+  const trackObjs=tracks.map(t=>{const ch=new Tone.Channel().connect(Tone.Destination);const inst=t.create();inst.connect(ch);return{inst,channel:ch};});
+
+  function buildSequencer(){const table=document.createElement('table');let head='<tr><th></th>';for(let s=1;s<=steps;s++)head+=`<th>${s}</th>`;head+='</tr>';table.innerHTML=head;tracks.forEach((trk,i)=>{const row=document.createElement('tr');row.innerHTML=`<td>${trk.name}</td>`;for(let s=0;s<steps;s++){const id=`t${i}s${s}`;row.innerHTML+=`<td><input type="checkbox" id="${id}"><label for="${id}"></label></td>`;}table.appendChild(row);});sequencer.appendChild(table);}
+  function buildMixer(){trackObjs.slice(0,12).forEach((trk,i)=>{const div=document.createElement('div');div.className='channel';div.innerHTML=`<div>${tracks[i].name}</div><input type="range" min="-60" max="0" value="0" step="1" class="fader" />`;div.querySelector('.fader').oninput=e=>trk.channel.volume.value=e.target.value;mixer.appendChild(div);});}
+
+  function sequencerPattern(){const pattern=[];document.querySelectorAll('#sequencer tr').forEach((row,i)=>{const rowPattern=[];row.querySelectorAll('input[type="checkbox"]').forEach(cb=>rowPattern.push(cb.checked));pattern.push(rowPattern);});return pattern;}
+
+  const model=new mm.MusicRNN('https://storage.googleapis.com/magentadata/js/checkpoints/music_rnn/melody_rnn');model.initialize();
+  function log(m){statusEl.textContent+="\n"+m;statusEl.scrollTop=statusEl.scrollHeight;}
+  function loadLiked(){try{return JSON.parse(localStorage.getItem('likedSeqs')||'[]');}catch{return [];}}
+  function saveLiked(seq){const data=loadLiked();data.push(seq);localStorage.setItem('likedSeqs',JSON.stringify(data));}
+
+  async function getSequence(file){log('Loading MIDI...');const reader=new FileReader();return new Promise(res=>{reader.onload=()=>{const midi=new Midi(reader.result);res(mm.midiToSequenceProto(midi));};reader.readAsArrayBuffer(file);});}
+  async function generateSequence(ns){log('Generating...');const q=mm.sequences.quantizeNoteSequence(ns,1);const r=await model.continueSequence(q,128,1.2);return mm.sequences.unquantizeSequence(r);}
+  function seqToPart(ns){const part=new Tone.Part();ns.notes.forEach(n=>{part.add(n.startTime,{midi:n.pitch,duration:n.endTime-n.startTime,velocity:n.velocity/127});});part.loop=false;return part;}
+
+  generate.onclick=async()=>{const file=midiUpload.files[0];let primer=null;if(file) primer=await getSequence(file);const liked=loadLiked();if(!primer&&liked.length) primer=liked[Math.floor(Math.random()*liked.length)];if(!primer){log('Upload MIDI or like a track first.');return;}const seq=await generateSequence(primer);currentSeq=seq;synth=new Tone.PolySynth(Tone.Synth).toDestination();generatedPart=seqToPart(seq);generatedPart.callback=time=>{const e=generatedPart.events.shift();synth.triggerAttackRelease(Tone.Midi(e.value.midi).toFrequency(),e.value.duration,time,e.value.velocity);generatedPart.events.push(e);};log('Ready to play.');};
+
+  playBtn.onclick=()=>{if(generatedPart){Tone.Transport.start();generatedPart.start(0);log('Playing...');}};
+  stopBtn.onclick=()=>{Tone.Transport.stop();Tone.Transport.cancel();log('Stopped.');};
+  pauseBtn.onclick=()=>{Tone.Transport.pause();log('Paused.');};
+  resumeBtn.onclick=()=>{Tone.Transport.start();log('Resumed.');};
+  likeBtn.onclick=()=>{if(currentSeq){saveLiked(currentSeq);log('Track liked.');}};
+  dislikeBtn.onclick=()=>{log('Track discarded.');};
+
+  promptGenerate.onclick=async()=>{const prompt=promptEl.value.trim();if(!prompt){log('Please enter a prompt.');return;}log('Generating from prompt ...');const primer=mm.sequences.createNoteSequence();const seq=await generateSequence(primer);currentSeq=seq;synth=new Tone.PolySynth(Tone.Synth).toDestination();generatedPart=seqToPart(seq);generatedPart.callback=time=>{const e=generatedPart.events.shift();synth.triggerAttackRelease(Tone.Midi(e.value.midi).toFrequency(),e.value.duration,time,e.value.velocity);generatedPart.events.push(e);};log('Ready.');};
+
+  playSimple.onclick=playBtn.onclick;
+  pauseSimple.onclick=pauseBtn.onclick;
+  resumeSimple.onclick=resumeBtn.onclick;
+  stopSimple.onclick=stopBtn.onclick;
+  </script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,296 @@
+const tabSimple = document.getElementById('tabSimple');
+const tabAdvanced = document.getElementById('tabAdvanced');
+const simpleModeEl = document.getElementById('simpleMode');
+const advancedModeEl = document.getElementById('advancedMode');
+
+const promptEl = document.getElementById('prompt');
+const promptGenerateBtn = document.getElementById('promptGenerate');
+const playSimpleBtn = document.getElementById('playSimple');
+const pauseSimpleBtn = document.getElementById('pauseSimple');
+const resumeSimpleBtn = document.getElementById('resumeSimple');
+const stopSimpleBtn = document.getElementById('stopSimple');
+
+const statusEl = document.getElementById('status');
+const generateBtn = document.getElementById('generate');
+const uploadEl = document.getElementById('midiUpload');
+const playBtn = document.getElementById('play');
+const stopBtn = document.getElementById('stop');
+const pauseBtn = document.getElementById('pause');
+const resumeBtn = document.getElementById('resume');
+const likeBtn = document.getElementById('like');
+const dislikeBtn = document.getElementById('dislike');
+const sequencerEl = document.getElementById('sequencer');
+const mixerEl = document.getElementById('mixer');
+
+let generatedPart;
+let synth;
+let currentSeq;
+
+// --- Retro Step Sequencer Setup ---
+const steps = 16;
+const trackDefs = [
+  {name: 'Kick', create: () => new Tone.MembraneSynth({pitchDecay:0.05})},
+  {name: 'Snare', create: () => new Tone.NoiseSynth({envelope:{attack:0.001,decay:0.2,sustain:0}})},
+  {name: 'HiHat', create: () => new Tone.NoiseSynth({envelope:{attack:0.001,decay:0.05,sustain:0}})},
+  {name: 'OpenHat', create: () => new Tone.NoiseSynth({envelope:{attack:0.001,decay:0.3,sustain:0}})},
+  {name: 'Tom', create: () => new Tone.MembraneSynth({octaves:2})},
+  {name: 'Cymbal', create: () => new Tone.MetalSynth()},
+  {name: 'FMSynth', create: () => new Tone.FMSynth()},
+  {name: 'Granular', create: () => new Tone.GrainPlayer('https://tonejs.github.io/audio/berklee/gong_1.mp3')},
+  {name: 'Additive', create: () => new Tone.PolySynth(Tone.Synth)}
+];
+
+const tracks = trackDefs.map(t => {
+  const chain = createChannel();
+  const inst = t.create();
+  inst.connect(chain.input);
+  return {name: t.name, synth: inst, channel: chain.channel};
+});
+
+function createChannel(){
+  const channel = new Tone.Channel({pan:0, volume:0});
+  const distortion = new Tone.Distortion(0.1);
+  const delay = new Tone.FeedbackDelay('8n', 0.25);
+  const chorus = new Tone.Chorus(4, 2.5, 0.3).start();
+  const tremolo = new Tone.Tremolo(8, 0.5).start();
+  const filter = new Tone.Filter(1200, 'lowpass');
+  const compressor = new Tone.Compressor(-10, 3);
+  distortion.chain(delay, chorus, tremolo, filter, compressor, channel, Tone.Destination);
+  return {input: distortion, channel};
+}
+
+function createSequencerUI(){
+  const table = document.createElement('table');
+  let head = '<tr><th></th>';
+  for(let s=1;s<=steps;s++) head += `<th>${s}</th>`;
+  head += '</tr>';
+  table.innerHTML = head;
+  tracks.forEach((trk,i)=>{
+    const row = document.createElement('tr');
+    row.dataset.track=i;
+    let cells = `<td>${trk.name}</td>`;
+    for(let s=0;s<steps;s++){
+      const id = `t${i}s${s}`;
+      cells += `<td><input type="checkbox" id="${id}"><label for="${id}"></label></td>`;
+    }
+    row.innerHTML = cells;
+    table.appendChild(row);
+  });
+  sequencerEl.appendChild(table);
+}
+
+function createMixerUI(){
+  tracks.slice(0,12).forEach((trk,i)=>{
+    const div = document.createElement('div');
+    div.className = 'channel';
+    div.innerHTML = `<div>${trk.name}</div><input type="range" min="-60" max="0" value="0" step="1" class="fader" />`;
+    const fader = div.querySelector('.fader');
+    fader.oninput = e => trk.channel.volume.value = e.target.value;
+    mixerEl.appendChild(div);
+  });
+}
+
+function showSimple(){
+  simpleModeEl.classList.remove('hidden');
+  advancedModeEl.classList.add('hidden');
+  tabSimple.classList.add('active');
+  tabAdvanced.classList.remove('active');
+}
+
+function showAdvanced(){
+  advancedModeEl.classList.remove('hidden');
+  simpleModeEl.classList.add('hidden');
+  tabAdvanced.classList.add('active');
+  tabSimple.classList.remove('active');
+  if(!sequencerEl.hasChildNodes()){
+    createSequencerUI();
+    createMixerUI();
+  }
+}
+
+
+let currentStep = 0;
+Tone.Transport.scheduleRepeat(time=>{
+  tracks.forEach((trk,i)=>{
+    const box = document.getElementById(`t${i}s${currentStep}`);
+    if(box && box.checked){
+      if(trk.synth.triggerAttackRelease){
+        trk.synth.triggerAttackRelease('C3','16n',time);
+      } else if(trk.synth.start){
+        trk.synth.start(time);
+      }
+    }
+  });
+  currentStep = (currentStep + 1) % steps;
+}, '16n');
+
+const model = new mm.MusicRNN('https://storage.googleapis.com/magentadata/js/checkpoints/music_rnn/melody_rnn');
+model.initialize();
+
+function log(msg) {
+  statusEl.textContent += "\n" + msg;
+  statusEl.scrollTop = statusEl.scrollHeight;
+}
+
+const LIKED_KEY = 'likedSequences';
+
+function loadLikedSequences() {
+  const data = localStorage.getItem(LIKED_KEY);
+  if (!data) return [];
+  try {
+    return JSON.parse(data);
+  } catch {
+    return [];
+  }
+}
+
+function saveLikedSequence(seq) {
+  const liked = loadLikedSequences();
+  liked.push(seq);
+  localStorage.setItem(LIKED_KEY, JSON.stringify(liked));
+}
+
+async function getSequence(file) {
+  log('Loading MIDI...');
+  const reader = new FileReader();
+  return new Promise(resolve => {
+    reader.onload = () => {
+      const midi = new Midi(reader.result);
+      const ns = mm.midiToSequenceProto(midi);
+      resolve(ns);
+    };
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+async function generateSequence(ns) {
+  log('Generating...');
+  const quantized = mm.sequences.quantizeNoteSequence(ns, 1);
+  const rnnSeq = await model.continueSequence(quantized, 128, 1.2);
+  const unquantized = mm.sequences.unquantizeSequence(rnnSeq);
+  return unquantized;
+}
+
+function sequenceToPart(ns) {
+  const {Part} = Tone;
+  const part = new Part();
+  ns.notes.forEach(note => {
+    part.add(note.startTime, {
+      midi: note.pitch,
+      duration: note.endTime - note.startTime,
+      velocity: note.velocity / 127
+    });
+  });
+  part.loop = false;
+  return part;
+}
+
+async function generateFromPrompt(prompt) {
+  log('Requesting AI generation...');
+  try {
+    const resp = await fetch('https://api.example.com/musicgen', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt })
+    });
+    const buf = await resp.arrayBuffer();
+    const midi = new Midi(buf);
+    return mm.midiToSequenceProto(midi);
+  } catch (e) {
+    log('Remote generation failed, using local RNN.');
+    const primer = mm.sequences.quantizeNoteSequence(mm.sequences.createNoteSequence(), 1);
+    return generateSequence(primer);
+  }
+}
+
+generateBtn.onclick = async () => {
+  const file = uploadEl.files[0];
+  let primer = null;
+  if (file) {
+    primer = await getSequence(file);
+  }
+  const liked = loadLikedSequences();
+  if (!primer && liked.length > 0) {
+    primer = liked[Math.floor(Math.random() * liked.length)];
+    log('Using liked sequence as primer.');
+  }
+  if (!primer) {
+    log('Please upload a MIDI file or like a generated track first.');
+    return;
+  }
+
+  const genSeq = await generateSequence(primer);
+  currentSeq = genSeq;
+
+  synth = new Tone.PolySynth(Tone.Synth).toDestination();
+  generatedPart = sequenceToPart(genSeq);
+  generatedPart.callback = time => {
+    const event = generatedPart.events.shift();
+    synth.triggerAttackRelease(Tone.Midi(event.value.midi).toFrequency(), event.value.duration, time, event.value.velocity);
+    generatedPart.events.push(event);
+  };
+  log('Ready to play.');
+};
+
+playBtn.onclick = () => {
+  if (generatedPart) {
+    Tone.Transport.start();
+    generatedPart.start(0);
+    log('Playing...');
+  }
+};
+
+stopBtn.onclick = () => {
+  Tone.Transport.stop();
+  Tone.Transport.cancel();
+  log('Stopped.');
+};
+
+pauseBtn.onclick = () => {
+  Tone.Transport.pause();
+  log('Paused.');
+};
+
+resumeBtn.onclick = () => {
+  Tone.Transport.start();
+  log('Resumed.');
+};
+
+likeBtn.onclick = () => {
+  if (currentSeq) {
+    saveLikedSequence(currentSeq);
+    log('Track saved to liked sequences.');
+  }
+};
+
+dislikeBtn.onclick = () => {
+  log('Track discarded.');
+};
+
+promptGenerateBtn.onclick = async () => {
+  const prompt = promptEl.value.trim();
+  if(!prompt){
+    log('Please enter a prompt.');
+    return;
+  }
+  const seq = await generateFromPrompt(prompt);
+  currentSeq = seq;
+  synth = new Tone.PolySynth(Tone.Synth).toDestination();
+  generatedPart = sequenceToPart(seq);
+  generatedPart.callback = time => {
+    const event = generatedPart.events.shift();
+    synth.triggerAttackRelease(Tone.Midi(event.value.midi).toFrequency(), event.value.duration, time, event.value.velocity);
+    generatedPart.events.push(event);
+  };
+  log('Ready to play.');
+};
+
+tabSimple.onclick = showSimple;
+tabAdvanced.onclick = showAdvanced;
+
+playSimpleBtn.onclick = playBtn.onclick;
+pauseSimpleBtn.onclick = pauseBtn.onclick;
+resumeSimpleBtn.onclick = resumeBtn.onclick;
+stopSimpleBtn.onclick = stopBtn.onclick;
+
+showSimple();

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,118 @@
+body {
+  background: #111;
+  color: #0f0;
+  font-family: 'Press Start 2P', cursive;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+}
+
+#app {
+  text-align: center;
+  background: #222;
+  padding: 20px;
+  border: 4px solid #0f0;
+}
+
+#tabs {
+  margin-bottom: 10px;
+}
+
+#tabs button.active {
+  background: #8f8;
+}
+
+.hidden {
+  display: none;
+}
+
+textarea {
+  width: 100%;
+  height: 60px;
+  margin-top: 10px;
+  font-family: inherit;
+}
+
+button {
+  font-family: inherit;
+  margin: 5px;
+  padding: 10px 20px;
+  background: #0f0;
+  color: #000;
+  border: none;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #8f8;
+}
+
+#vote {
+  margin-top: 10px;
+}
+
+#vote button {
+  padding: 5px 10px;
+}
+
+pre {
+  white-space: pre-wrap;
+  text-align: left;
+  background: #000;
+  padding: 10px;
+  margin-top: 10px;
+  color: #0f0;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+/* Sequencer grid */
+#sequencer table {
+  border-collapse: collapse;
+  margin: 10px auto;
+}
+
+#sequencer th,
+#sequencer td {
+  border: 1px solid #0f0;
+  padding: 2px;
+}
+
+#sequencer td label {
+  display: block;
+  width: 20px;
+  height: 20px;
+  background: #000;
+  cursor: pointer;
+}
+
+#sequencer input[type="checkbox"] {
+  display: none;
+}
+
+#sequencer input[type="checkbox"]:checked + label {
+  background: #0f0;
+}
+
+/* Mixer */
+#mixer {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.channel {
+  border: 1px solid #0f0;
+  padding: 5px;
+  margin: 0 2px;
+  text-align: center;
+}
+
+.fader {
+  writing-mode: bt-lr;
+  -webkit-appearance: slider-vertical;
+  width: 30px;
+  height: 100px;
+}


### PR DESCRIPTION
## Summary
- start app in simple tab with text prompt and playback controls
- add advanced tab with existing linear editor and mixer
- implement tab switching logic in script
- placeholder fetch to remote music generator and fallback to local RNN

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68844c08086083219939aa35deb0ad60